### PR TITLE
#1 Added padding on body to prevent 'body jump'

### DIFF
--- a/disable-scroll.js
+++ b/disable-scroll.js
@@ -10,7 +10,7 @@
     function($document) {
       var lastElementToDisableScroll = null;
       $document.find("head").append(
-        "<style type='text/css'>.ng-disable-scroll{overflow:hidden !important;}</style>"
+        "<style type='text/css'>body.ng-disable-scroll-pad{padding-right: 17px;} .ng-disable-scroll{overflow:hidden !important;}</style>"
       );
       return {
         restrict: "A",
@@ -21,9 +21,11 @@
             if (shouldDisable) {
               lastElementToDisableScroll = $element;
               rootHtmlElement.addClass("ng-disable-scroll");
+              $document[0].querySelector('body').classList.add('ng-disable-scroll-pad');
               $document.bind("touchmove", touchHandler);
             } else {
               unbindHandler();
+              $document[0].querySelector('body').classList.remove('ng-disable-scroll-pad');
             }
           });
 


### PR DESCRIPTION
When overflow is removed the body 'jumps' because the scroll bars space is removed.  Adding padding-right maintains the space the scroll bar took up and prevents body jump.